### PR TITLE
Create GitHub Pages one page report generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# ppmtool
+# One Page Report Generator
+
+A zero-backend tool that turns Smartsheet trackers and meeting notes into executive-ready one page summaries with traffic lights, deltas, and blockers. Designed to run entirely on GitHub Pages – clone, push, and enable Pages to ship.
+
+## ✨ Features
+
+- **Smartsheet integration** – paste an access token and sheet ID to pull rows client-side.
+- **Google Docs notes** – import shared docs (exported as plain text) or paste notes manually.
+- **Tone controls** – choose executive, team, detailed, or craft a custom narrative prompt.
+- **Traffic lights & deltas** – configurable column mapping for status, week-over-week movement, and blockers.
+- **Exports** – download the generated one pager as PDF, PowerPoint, or DOCX.
+- **Improvement ideas** – baked-in suggestions for growing the product beyond MVP.
+
+## 🚀 Getting started
+
+1. Clone the repository and push it to your GitHub account.
+2. Enable GitHub Pages for the repository (root directory). The static assets require no build step.
+3. Browse to the published site.
+
+## 🔌 Connecting data sources
+
+### Smartsheet
+
+1. Generate a Smartsheet API access token with read permissions.
+2. Enter the token and sheet ID, then map the relevant column titles (status, delta, blockers, owner).
+3. Click **Load sheet** – data stays in the browser only.
+
+### Google Docs
+
+1. Share your meeting notes document with “Anyone with the link – Viewer”.
+2. Paste the document ID (the long string in the URL) and click **Load Google Doc**.
+3. Alternatively, paste notes directly into the textarea.
+
+## 🧠 Generating the report
+
+1. Choose the tone for the narrative and optionally add emphasis prompts.
+2. Press **Generate Report** to build the one page summary.
+3. Export via PDF, PPTX, or DOCX buttons.
+
+## 🛡️ Security
+
+- No credentials are persisted or sent to a backend; everything runs within your browser session.
+- Revoke API tokens when you are done.
+
+## 💡 Future enhancements
+
+- OAuth-powered Google and Microsoft connectors for secure enterprise deployment.
+- Historical Smartsheet snapshots to quantify velocity and progress trends automatically.
+- AI-generated mitigations and owner nudges based on blocker patterns.
+- Slack/Teams publishing workflows with tone-aware variants per stakeholder group.
+
+## 🛠️ Development
+
+Static site – edit `index.html`, `assets/style.css`, and `assets/app.js`. No build tooling required.

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,0 +1,739 @@
+const state = {
+  sheet: null,
+  report: null,
+  items: [],
+};
+
+const elements = {
+  smartsheetToken: document.getElementById('smartsheet-token'),
+  smartsheetSheetId: document.getElementById('smartsheet-sheet-id'),
+  loadSmartsheet: document.getElementById('load-smartsheet'),
+  smartsheetStatus: document.getElementById('smartsheet-status'),
+  columnKeyResult: document.getElementById('column-key-result'),
+  columnStatus: document.getElementById('column-status'),
+  columnDelta: document.getElementById('column-delta'),
+  columnBlockers: document.getElementById('column-blockers'),
+  columnOwner: document.getElementById('column-owner'),
+  meetingNotes: document.getElementById('meeting-notes'),
+  googleDocId: document.getElementById('google-doc-id'),
+  loadGoogleDoc: document.getElementById('load-google-doc'),
+  googleDocStatus: document.getElementById('google-doc-status'),
+  toneSelect: document.getElementById('tone-select'),
+  customToneWrapper: document.getElementById('custom-tone-wrapper'),
+  customToneInput: document.getElementById('custom-tone-input'),
+  toneEmphasis: document.getElementById('tone-emphasis'),
+  generateReport: document.getElementById('generate-report'),
+  reportContent: document.getElementById('report-content'),
+  reportWarning: document.getElementById('report-warning'),
+  exportPdf: document.getElementById('export-pdf'),
+  exportPpt: document.getElementById('export-ppt'),
+  exportDocx: document.getElementById('export-docx'),
+};
+
+elements.loadSmartsheet.addEventListener('click', async () => {
+  const token = elements.smartsheetToken.value.trim();
+  const sheetId = elements.smartsheetSheetId.value.trim();
+
+  if (!token || !sheetId) {
+    setStatus(elements.smartsheetStatus, 'Provide both access token and sheet ID.', 'error');
+    return;
+  }
+
+  setStatus(elements.smartsheetStatus, 'Loading sheet…');
+  elements.loadSmartsheet.disabled = true;
+
+  try {
+    const sheet = await fetchSmartsheetSheet(token, sheetId);
+    state.sheet = sheet;
+    setStatus(elements.smartsheetStatus, `Loaded \"${sheet.name}\" with ${sheet.totalRowCount} rows.`, 'success');
+  } catch (error) {
+    console.error(error);
+    setStatus(elements.smartsheetStatus, error.message || 'Unable to load Smartsheet data.', 'error');
+  } finally {
+    elements.loadSmartsheet.disabled = false;
+  }
+});
+
+elements.loadGoogleDoc.addEventListener('click', async () => {
+  const docId = elements.googleDocId.value.trim();
+  if (!docId) {
+    setStatus(elements.googleDocStatus, 'Provide a Google Doc ID.', 'error');
+    return;
+  }
+
+  setStatus(elements.googleDocStatus, 'Fetching doc…');
+  elements.loadGoogleDoc.disabled = true;
+
+  try {
+    const text = await fetchGoogleDoc(docId);
+    elements.meetingNotes.value = text;
+    setStatus(elements.googleDocStatus, 'Loaded notes from Google Docs.', 'success');
+  } catch (error) {
+    console.error(error);
+    setStatus(elements.googleDocStatus, error.message || 'Unable to load document. Ensure it is shared publicly.', 'error');
+  } finally {
+    elements.loadGoogleDoc.disabled = false;
+  }
+});
+
+elements.toneSelect.addEventListener('change', () => {
+  const isCustom = elements.toneSelect.value === 'custom';
+  elements.customToneWrapper.classList.toggle('hidden', !isCustom);
+});
+
+elements.generateReport.addEventListener('click', () => {
+  const report = buildReport();
+  if (!report) {
+    return;
+  }
+
+  state.report = report;
+  renderReport(report);
+  setStatus(elements.reportWarning, '', '');
+});
+
+elements.exportPdf.addEventListener('click', () => {
+  if (!state.report) {
+    flashReportWarning('Generate the report before exporting.');
+    return;
+  }
+  exportPdf(state.report);
+});
+
+elements.exportPpt.addEventListener('click', () => {
+  if (!state.report) {
+    flashReportWarning('Generate the report before exporting.');
+    return;
+  }
+  exportPpt(state.report);
+});
+
+elements.exportDocx.addEventListener('click', () => {
+  if (!state.report) {
+    flashReportWarning('Generate the report before exporting.');
+    return;
+  }
+  exportDocx(state.report);
+});
+
+function setStatus(element, message, kind = '') {
+  element.textContent = message;
+  element.classList.remove('error', 'success');
+  if (kind) {
+    element.classList.add(kind);
+  }
+}
+
+async function fetchSmartsheetSheet(token, sheetId) {
+  const response = await fetch(`https://api.smartsheet.com/2.0/sheets/${encodeURIComponent(sheetId)}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    let message = `Smartsheet request failed (${response.status})`;
+    try {
+      const data = await response.json();
+      if (data && data.message) {
+        message = data.message;
+      }
+    } catch (error) {
+      // ignore
+    }
+    throw new Error(message);
+  }
+
+  return response.json();
+}
+
+async function fetchGoogleDoc(docId) {
+  const response = await fetch(`https://docs.google.com/document/d/${encodeURIComponent(docId)}/export?format=txt`);
+  if (!response.ok) {
+    throw new Error('Could not fetch document. Ensure link sharing is enabled.');
+  }
+  return response.text();
+}
+
+function buildReport() {
+  const notes = elements.meetingNotes.value.trim();
+  const tone = elements.toneSelect.value;
+  const emphasis = elements.toneEmphasis.value.trim();
+  const customTone = elements.customToneInput.value.trim();
+
+  if (!state.sheet) {
+    flashReportWarning('Load a Smartsheet sheet before generating the report.');
+    return null;
+  }
+
+  const mappings = {
+    keyResult: elements.columnKeyResult.value.trim(),
+    status: elements.columnStatus.value.trim(),
+    delta: elements.columnDelta.value.trim(),
+    blockers: elements.columnBlockers.value.trim(),
+    owner: elements.columnOwner.value.trim(),
+  };
+
+  const parsed = parseSmartsheet(state.sheet, mappings);
+
+  const narrative = composeNarrative(parsed, notes, tone, customTone, emphasis);
+
+  const report = {
+    generatedAt: new Date(),
+    sheetName: state.sheet.name,
+    tone: tone === 'custom' ? customTone || 'Custom' : tone,
+    emphasis,
+    notes,
+    items: parsed.items,
+    metrics: parsed.metrics,
+    blockers: parsed.blockers,
+    deltas: parsed.deltas,
+    meetingHighlights: extractHighlights(notes),
+    narrative,
+  };
+
+  return report;
+}
+
+function parseSmartsheet(sheet, mappings) {
+  const columnsById = new Map(sheet.columns.map((column) => [column.id, column]));
+  const columnsByTitle = new Map(sheet.columns.map((column) => [column.title.toLowerCase(), column]));
+
+  function getCellValue(row, columnName) {
+    if (!columnName) {
+      return '';
+    }
+    const column = columnsByTitle.get(columnName.toLowerCase());
+    if (!column) {
+      return '';
+    }
+    const cell = row.cells.find((c) => c.columnId === column.id);
+    if (!cell) {
+      return '';
+    }
+    return cell.displayValue ?? cell.value ?? '';
+  }
+
+  const items = [];
+  const blockers = [];
+  const deltas = [];
+  const statusCounter = { green: 0, yellow: 0, red: 0, other: 0 };
+
+  for (const row of sheet.rows) {
+    if (row.siblingId) {
+      // skip child rows to keep high-level summary concise
+      continue;
+    }
+
+    const name = getCellValue(row, mappings.keyResult) || getCellValue(row, 'Task Name') || row.cells[0]?.displayValue || 'Untitled';
+    const rawStatus = (getCellValue(row, mappings.status) || '').toString().toLowerCase();
+    const status = normalizeStatus(rawStatus);
+    const delta = getCellValue(row, mappings.delta);
+    const blocker = getCellValue(row, mappings.blockers);
+    const owner = getCellValue(row, mappings.owner);
+
+    if (blocker) {
+      blockers.push({ name, blocker, owner });
+    }
+    if (delta) {
+      deltas.push({ name, delta });
+    }
+
+    statusCounter[status] = (statusCounter[status] || 0) + 1;
+
+    items.push({
+      name,
+      status,
+      delta,
+      blocker,
+      owner,
+    });
+  }
+
+  const total = items.length || 1;
+  const metrics = [
+    {
+      label: 'Green',
+      value: statusCounter.green,
+      descriptor: `${Math.round((statusCounter.green / total) * 100)}% on track`,
+      tone: 'green',
+    },
+    {
+      label: 'Yellow',
+      value: statusCounter.yellow,
+      descriptor: `${Math.round((statusCounter.yellow / total) * 100)}% watch list`,
+      tone: 'yellow',
+    },
+    {
+      label: 'Red',
+      value: statusCounter.red,
+      descriptor: `${Math.round((statusCounter.red / total) * 100)}% critical`,
+      tone: 'red',
+    },
+  ];
+
+  return { items, blockers, deltas, metrics };
+}
+
+function normalizeStatus(status) {
+  if (!status) {
+    return 'other';
+  }
+  if (status.includes('green') || status === 'on track' || status === 'complete') {
+    return 'green';
+  }
+  if (status.includes('yellow') || status.includes('amber') || status.includes('watch')) {
+    return 'yellow';
+  }
+  if (status.includes('red') || status.includes('critical') || status.includes('behind')) {
+    return 'red';
+  }
+  return 'other';
+}
+
+function composeNarrative(parsed, notes, tone, customTone, emphasis) {
+  const toneConfig = getToneConfig(tone, customTone);
+  const totalItems = parsed.items.length;
+  const headline = `${parsed.metrics[0].value}/${totalItems} initiatives on track, ${parsed.metrics[2].value} critical`;
+  const blockersSummary = parsed.blockers.length
+    ? `${parsed.blockers.length} blocker${parsed.blockers.length > 1 ? 's' : ''} need attention`
+    : 'No active blockers reported';
+  const deltaSummary = parsed.deltas.length
+    ? `Key movements: ${parsed.deltas
+        .slice(0, 3)
+        .map((d) => `${d.name} (${d.delta})`)
+        .join('; ')}`
+    : 'Minimal movement week-over-week';
+
+  const emphasisText = emphasis ? `Emphasis: ${emphasis}.` : '';
+
+  return `${toneConfig.opening} ${headline}. ${blockersSummary}. ${deltaSummary}. ${emphasisText} ${toneConfig.closing}`.trim();
+}
+
+function getToneConfig(tone, customTone) {
+  const base = {
+    opening: 'Summary:',
+    closing: '',
+  };
+
+  switch (tone) {
+    case 'executive':
+      return {
+        opening: 'Executive summary:',
+        closing: 'Focus decisions on red items and unblock owners before next checkpoint.',
+      };
+    case 'team':
+      return {
+        opening: 'Team sync recap:',
+        closing: 'Let’s align on owners and next steps to sustain momentum.',
+      };
+    case 'detailed':
+      return {
+        opening: 'Detailed update:',
+        closing: 'See notes below for supporting context and follow-ups.',
+      };
+    case 'custom':
+      return {
+        opening: `${customTone || 'Custom summary'}:`,
+        closing: 'Tailored narrative complete.',
+      };
+    default:
+      return base;
+  }
+}
+
+function extractHighlights(notes) {
+  if (!notes) {
+    return [];
+  }
+  const lines = notes
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const bulletLines = lines.filter((line) => /^[-*•]/.test(line));
+  if (bulletLines.length >= 3) {
+    return bulletLines.slice(0, 6).map((line) => line.replace(/^[-*•]\s*/, ''));
+  }
+
+  return lines.slice(0, 6);
+}
+
+function renderReport(report) {
+  const container = document.createElement('div');
+  container.className = 'report-content';
+
+  container.append(
+    renderMetrics(report.metrics),
+    renderTrafficLights(report.items),
+    renderBlockers(report.blockers),
+    renderDeltas(report.deltas),
+    renderNarrative(report),
+    renderMeetingHighlights(report.meetingHighlights)
+  );
+
+  elements.reportContent.replaceChildren(container);
+}
+
+function renderMetrics(metrics) {
+  const section = document.createElement('section');
+  section.className = 'report-section';
+
+  const title = document.createElement('h3');
+  title.textContent = 'Overall health';
+  section.appendChild(title);
+
+  const grid = document.createElement('div');
+  grid.className = 'metrics-grid';
+
+  metrics.forEach((metric) => {
+    const card = document.createElement('div');
+    card.className = 'metric-card';
+    card.innerHTML = `<strong>${metric.value}</strong><span>${metric.label}</span><small>${metric.descriptor}</small>`;
+    grid.appendChild(card);
+  });
+
+  section.appendChild(grid);
+  return section;
+}
+
+function renderTrafficLights(items) {
+  const section = document.createElement('section');
+  section.className = 'report-section';
+
+  const title = document.createElement('h3');
+  title.textContent = 'Traffic lights';
+  section.appendChild(title);
+
+  const table = document.createElement('table');
+  table.className = 'traffic-table';
+  const thead = document.createElement('thead');
+  thead.innerHTML = '<tr><th>Initiative</th><th>Status</th><th>Delta vs last week</th><th>Owner</th></tr>';
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  items.slice(0, 12).forEach((item) => {
+    const row = document.createElement('tr');
+    row.innerHTML = `
+      <td>${escapeHtml(item.name)}</td>
+      <td>${renderStatusBadge(item.status)}</td>
+      <td>${escapeHtml(item.delta || '—')}</td>
+      <td>${escapeHtml(item.owner || '—')}</td>
+    `;
+    tbody.appendChild(row);
+  });
+  table.appendChild(tbody);
+  section.appendChild(table);
+  return section;
+}
+
+function renderBlockers(blockers) {
+  const section = document.createElement('section');
+  section.className = 'report-section';
+  const title = document.createElement('h3');
+  title.textContent = 'Blockers';
+  section.appendChild(title);
+
+  if (!blockers.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No blockers reported.';
+    section.appendChild(empty);
+    return section;
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'blockers-list';
+  blockers.slice(0, 6).forEach((item) => {
+    const li = document.createElement('li');
+    const owner = item.owner ? ` — Owner: ${escapeHtml(item.owner)}` : '';
+    li.innerHTML = `<strong>${escapeHtml(item.name)}</strong>: ${escapeHtml(item.blocker)}${owner}`;
+    list.appendChild(li);
+  });
+  section.appendChild(list);
+  return section;
+}
+
+function renderDeltas(deltas) {
+  const section = document.createElement('section');
+  section.className = 'report-section';
+  const title = document.createElement('h3');
+  title.textContent = 'Delta vs last week';
+  section.appendChild(title);
+
+  if (!deltas.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No notable movement captured.';
+    section.appendChild(empty);
+    return section;
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'notes-list';
+  deltas.slice(0, 6).forEach((delta) => {
+    const li = document.createElement('li');
+    li.innerHTML = `<strong>${escapeHtml(delta.name)}</strong>: ${escapeHtml(delta.delta)}`;
+    list.appendChild(li);
+  });
+  section.appendChild(list);
+  return section;
+}
+
+function renderNarrative(report) {
+  const section = document.createElement('section');
+  section.className = 'report-section';
+  const title = document.createElement('h3');
+  title.textContent = 'Narrative';
+  section.appendChild(title);
+
+  const block = document.createElement('div');
+  block.className = 'narrative';
+  block.textContent = report.narrative;
+  section.appendChild(block);
+  return section;
+}
+
+function renderMeetingHighlights(highlights) {
+  const section = document.createElement('section');
+  section.className = 'report-section';
+  const title = document.createElement('h3');
+  title.textContent = 'Meeting highlights';
+  section.appendChild(title);
+
+  if (!highlights.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'Add meeting notes to surface highlights.';
+    section.appendChild(empty);
+    return section;
+  }
+
+  const list = document.createElement('ul');
+  list.className = 'notes-list';
+  highlights.forEach((item) => {
+    const li = document.createElement('li');
+    li.textContent = item;
+    list.appendChild(li);
+  });
+  section.appendChild(list);
+  return section;
+}
+
+function renderStatusBadge(status) {
+  const classes = {
+    green: 'badge green',
+    yellow: 'badge yellow',
+    red: 'badge red',
+    other: 'badge',
+  };
+  const labels = {
+    green: 'Green',
+    yellow: 'Yellow',
+    red: 'Red',
+    other: '—',
+  };
+  return `<span class="${classes[status]}">● ${labels[status]}</span>`;
+}
+
+function escapeHtml(value) {
+  const div = document.createElement('div');
+  div.textContent = value;
+  return div.innerHTML;
+}
+
+function flashReportWarning(message) {
+  elements.reportWarning.textContent = message;
+  elements.reportWarning.classList.remove('hidden');
+  elements.reportWarning.classList.add('error');
+  elements.reportWarning.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  setTimeout(() => elements.reportWarning.classList.add('hidden'), 3500);
+}
+
+function exportPdf(report) {
+  const doc = new window.jspdf.jsPDF({ unit: 'pt', format: 'a4' });
+  const margin = 40;
+  let cursorY = margin;
+  const lineHeight = 18;
+
+  const pageWidth = doc.internal.pageSize.getWidth() - margin * 2;
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(18);
+  doc.text('One Page Report', margin, cursorY);
+  cursorY += lineHeight;
+
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(10);
+  doc.text(`Source sheet: ${report.sheetName}`, margin, cursorY);
+  cursorY += lineHeight;
+  doc.text(`Generated: ${report.generatedAt.toLocaleString()}`, margin, cursorY);
+  cursorY += lineHeight * 1.5;
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(12);
+  doc.text('Narrative', margin, cursorY);
+  cursorY += lineHeight;
+  doc.setFont('helvetica', 'normal');
+  cursorY = addMultilineText(doc, report.narrative, margin, cursorY, pageWidth, lineHeight, margin);
+  cursorY += lineHeight;
+
+  doc.setFont('helvetica', 'bold');
+  doc.text('Traffic lights', margin, cursorY);
+  cursorY += lineHeight;
+  report.items.slice(0, 12).forEach((item) => {
+    const line = `${item.name} — ${item.status.toUpperCase()} | Δ ${item.delta || '—'} | Owner ${item.owner || '—'}`;
+    cursorY = addMultilineText(doc, line, margin + 10, cursorY, pageWidth - 20, lineHeight, margin);
+  });
+  cursorY += lineHeight;
+
+  doc.setFont('helvetica', 'bold');
+  doc.text('Blockers', margin, cursorY);
+  cursorY += lineHeight;
+  if (!report.blockers.length) {
+    doc.setFont('helvetica', 'normal');
+    doc.text('None reported.', margin + 10, cursorY);
+    cursorY += lineHeight;
+  } else {
+    report.blockers.slice(0, 6).forEach((blocker) => {
+      const line = `${blocker.name}: ${blocker.blocker}${blocker.owner ? ` (Owner ${blocker.owner})` : ''}`;
+      cursorY = addMultilineText(doc, line, margin + 10, cursorY, pageWidth - 20, lineHeight, margin);
+    });
+  }
+
+  cursorY += lineHeight;
+  doc.setFont('helvetica', 'bold');
+  doc.text('Meeting highlights', margin, cursorY);
+  cursorY += lineHeight;
+  if (!report.meetingHighlights.length) {
+    doc.setFont('helvetica', 'normal');
+    doc.text('Add meeting notes to include highlights.', margin + 10, cursorY);
+  } else {
+    report.meetingHighlights.forEach((highlight) => {
+      cursorY = addMultilineText(doc, `• ${highlight}`, margin + 10, cursorY, pageWidth - 20, lineHeight, margin);
+    });
+  }
+
+  doc.save('one-page-report.pdf');
+}
+
+function addMultilineText(doc, text, x, cursorY, maxWidth, lineHeight, margin) {
+  const lines = doc.splitTextToSize(text, maxWidth);
+  lines.forEach((line) => {
+    if (cursorY > doc.internal.pageSize.getHeight() - margin) {
+      doc.addPage();
+      cursorY = margin;
+    }
+    doc.text(line, x, cursorY);
+    cursorY += lineHeight;
+  });
+  return cursorY;
+}
+
+function exportPpt(report) {
+  const pptx = new window.PptxGenJS();
+  const slide = pptx.addSlide();
+  slide.addText('One Page Report', { x: 0.5, y: 0.3, fontSize: 24, bold: true });
+  slide.addText(`Sheet: ${report.sheetName}`, { x: 0.5, y: 0.9, fontSize: 12 });
+  slide.addText(report.narrative, {
+    x: 0.5,
+    y: 1.2,
+    w: 9,
+    h: 1.6,
+    fontSize: 12,
+    color: '2d3748',
+    fill: { color: 'f1f5f9' },
+    margin: 0.1,
+  });
+
+  const tableRows = [
+    ['Initiative', 'Status', 'Delta', 'Owner'],
+    ...report.items.slice(0, 10).map((item) => [
+      truncate(item.name, 60),
+      item.status.toUpperCase(),
+      truncate(item.delta || '—', 40),
+      truncate(item.owner || '—', 20),
+    ]),
+  ];
+
+  slide.addTable(tableRows, {
+    x: 0.5,
+    y: 3,
+    w: 9,
+    colW: [4.2, 1.4, 2.4, 1.2],
+    fontSize: 11,
+    color: '1f2937',
+    fill: 'ffffff',
+    valign: 'middle',
+    border: { type: 'solid', color: 'd1d5db', pt: 1 },
+    bold: true,
+    rowH: 0.45,
+  });
+
+  slide.addText('Blockers', { x: 0.5, y: 6, fontSize: 14, bold: true });
+  slide.addText(
+    report.blockers.length
+      ? report.blockers
+          .slice(0, 4)
+          .map((item) => `${truncate(item.name, 30)}: ${truncate(item.blocker, 40)}`)
+          .join('\n')
+      : 'None reported.',
+    { x: 0.5, y: 6.3, fontSize: 11, lineSpacingMultiple: 1.15 }
+  );
+
+  pptx.writeFile({ fileName: 'one-page-report.pptx' });
+}
+
+function truncate(text, max) {
+  if (!text) {
+    return text;
+  }
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+function exportDocx(report) {
+  const { Document, Packer, Paragraph, TextRun } = window.docx;
+  const doc = new Document({
+    sections: [
+      {
+        properties: {},
+        children: [
+          new Paragraph({
+            children: [new TextRun({ text: 'One Page Report', bold: true, size: 32 })],
+          }),
+          new Paragraph({ text: `Sheet: ${report.sheetName}`, spacing: { after: 200 } }),
+          new Paragraph({ text: report.narrative, spacing: { after: 300 } }),
+          new Paragraph({ text: 'Traffic lights', heading: 'Heading2' }),
+          ...report.items.slice(0, 12).map(
+            (item) =>
+              new Paragraph({
+                text: `${item.name} — ${item.status.toUpperCase()} | Δ ${item.delta || '—'} | Owner ${item.owner || '—'}`,
+                spacing: { after: 100 },
+              })
+          ),
+          new Paragraph({ text: 'Blockers', heading: 'Heading2' }),
+          ...(report.blockers.length
+            ? report.blockers.slice(0, 6).map(
+                (blocker) =>
+                  new Paragraph({
+                    text: `${blocker.name}: ${blocker.blocker}${blocker.owner ? ` (Owner ${blocker.owner})` : ''}`,
+                    spacing: { after: 100 },
+                  })
+              )
+            : [new Paragraph({ text: 'None reported.', spacing: { after: 100 } })]),
+          new Paragraph({ text: 'Meeting highlights', heading: 'Heading2' }),
+          ...(report.meetingHighlights.length
+            ? report.meetingHighlights.map((highlight) => new Paragraph({ text: `• ${highlight}`, spacing: { after: 100 } }))
+            : [new Paragraph({ text: 'Add meeting notes to include highlights.', spacing: { after: 100 } })]),
+        ],
+      },
+    ],
+  });
+
+  Packer.toBlob(doc).then((blob) => {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'one-page-report.docx';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,318 @@
+:root {
+  --bg: #f5f6fa;
+  --panel-bg: #ffffff;
+  --border: #d7d7e0;
+  --text: #1f1f26;
+  --muted: #6c6c80;
+  --primary: #3056d3;
+  --primary-contrast: #ffffff;
+  --green: #1f9d55;
+  --yellow: #f59e0b;
+  --red: #dc2626;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+h1, h2, h3 {
+  margin-top: 0;
+  color: var(--text);
+}
+
+p {
+  color: var(--muted);
+}
+
+.app-header {
+  padding: 2rem clamp(1.5rem, 4vw, 4rem);
+  background: linear-gradient(135deg, #1c1c28 0%, #273469 50%, #3056d3 100%);
+  color: var(--primary-contrast);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.app-header h1 {
+  color: var(--primary-contrast);
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+  margin-bottom: 0.5rem;
+}
+
+.app-header p {
+  color: rgba(255, 255, 255, 0.85);
+  max-width: 40rem;
+}
+
+.header-actions {
+  margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.header-actions button {
+  width: max-content;
+}
+
+.export-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+button {
+  padding: 0.65rem 1.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  background: #fff;
+  color: var(--text);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button.primary {
+  background: var(--primary);
+  color: var(--primary-contrast);
+  border-color: transparent;
+}
+
+button.secondary {
+  background: rgba(48, 86, 211, 0.1);
+  border-color: rgba(48, 86, 211, 0.25);
+  color: #1e2a78;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(20, 20, 43, 0.08);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.app-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  gap: 1.5rem;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  flex: 1;
+}
+
+.panel {
+  background: var(--panel-bg);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(20, 20, 43, 0.05);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel.report {
+  grid-column: 1 / -1;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+input, textarea, select {
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.8rem;
+  font-family: inherit;
+  font-size: 1rem;
+  background: #fafafa;
+  transition: border 0.15s ease, box-shadow 0.15s ease;
+}
+
+input:focus, textarea:focus, select:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(48, 86, 211, 0.15);
+  outline: none;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 12rem;
+}
+
+.mapping summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.mapping-grid {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.inline-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.status-message {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.status-message.error {
+  color: var(--red);
+}
+
+.status-message.success {
+  color: var(--green);
+}
+
+.hint {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.report-content {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.report-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.report-section h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #111827;
+}
+
+.traffic-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.traffic-table th, .traffic-table td {
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid rgba(17, 24, 39, 0.08);
+  text-align: left;
+}
+
+.traffic-table th {
+  background: rgba(48, 86, 211, 0.06);
+  font-weight: 600;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+}
+
+.badge.green {
+  color: var(--green);
+  background: rgba(31, 157, 85, 0.12);
+}
+
+.badge.yellow {
+  color: var(--yellow);
+  background: rgba(245, 158, 11, 0.12);
+}
+
+.badge.red {
+  color: var(--red);
+  background: rgba(220, 38, 38, 0.12);
+}
+
+.blockers-list, .notes-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.narrative {
+  background: linear-gradient(135deg, rgba(48, 86, 211, 0.08), rgba(29, 78, 216, 0.05));
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  color: #1f2937;
+  line-height: 1.6;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 1rem;
+}
+
+.metric-card {
+  background: rgba(17, 24, 39, 0.04);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.metric-card strong {
+  font-size: 1.75rem;
+}
+
+.metric-card span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.app-footer {
+  padding: 1.5rem;
+  text-align: center;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+@media (max-width: 768px) {
+  .header-actions {
+    width: 100%;
+    align-items: flex-start;
+  }
+
+  .export-buttons {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>One Page Report Generator</title>
+  <link rel="stylesheet" href="assets/style.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="app-header">
+    <div class="header-content">
+      <h1>One Page Report Generator</h1>
+      <p>Create executive-ready one pagers with traffic lights, deltas, and blockers directly from Smartsheet trackers and meeting notes.</p>
+    </div>
+    <div class="header-actions">
+      <button id="generate-report" class="primary">Generate Report</button>
+      <div class="export-buttons">
+        <button id="export-pdf">Export PDF</button>
+        <button id="export-ppt">Export PPT</button>
+        <button id="export-docx">Export DOCX</button>
+      </div>
+    </div>
+  </header>
+
+  <main class="app-grid">
+    <section class="panel">
+      <h2>1. Smartsheet Connection</h2>
+      <p class="hint">Use a Smartsheet API access token with read permissions. Nothing is stored on our servers.</p>
+      <label>Access token
+        <input type="password" id="smartsheet-token" placeholder="smartsheet-access-token" autocomplete="off" />
+      </label>
+      <label>Sheet ID
+        <input type="text" id="smartsheet-sheet-id" placeholder="1234567890" />
+      </label>
+      <details class="mapping">
+        <summary>Column mapping</summary>
+        <div class="mapping-grid">
+          <label>Key Result column
+            <input type="text" id="column-key-result" placeholder="Key Result" />
+          </label>
+          <label>Status column
+            <input type="text" id="column-status" placeholder="Status" />
+          </label>
+          <label>Delta column
+            <input type="text" id="column-delta" placeholder="Delta vs Last Week" />
+          </label>
+          <label>Blockers column
+            <input type="text" id="column-blockers" placeholder="Blockers" />
+          </label>
+          <label>Owner column (optional)
+            <input type="text" id="column-owner" placeholder="Owner" />
+          </label>
+        </div>
+      </details>
+      <button id="load-smartsheet" class="secondary">Load sheet</button>
+      <p id="smartsheet-status" class="status-message"></p>
+    </section>
+
+    <section class="panel">
+      <h2>2. Meeting notes</h2>
+      <p class="hint">Paste notes or pull from a shared Google Doc (must allow "Anyone with the link").</p>
+      <label>Google Doc ID
+        <input type="text" id="google-doc-id" placeholder="e.g. 1A2B3C4D..." />
+      </label>
+      <div class="inline-actions">
+        <button id="load-google-doc" class="secondary">Load Google Doc</button>
+        <span id="google-doc-status" class="status-message"></span>
+      </div>
+      <label>Meeting notes
+        <textarea id="meeting-notes" rows="12" placeholder="Paste notes here..."></textarea>
+      </label>
+    </section>
+
+    <section class="panel">
+      <h2>3. Tone & narrative</h2>
+      <label for="tone-select">Tone</label>
+      <select id="tone-select">
+        <option value="executive">Executive (concise, data first)</option>
+        <option value="team">Team (collaborative, action oriented)</option>
+        <option value="detailed">Detailed (context rich)</option>
+        <option value="custom">Custom</option>
+      </select>
+      <label id="custom-tone-wrapper" class="hidden">Custom tone prompt
+        <input type="text" id="custom-tone-input" placeholder="e.g. optimistic, inspirational" />
+      </label>
+      <label>Key outcomes emphasis
+        <input type="text" id="tone-emphasis" placeholder="e.g. Emphasize customer impact and schedule risk" />
+      </label>
+      <div class="ideas">
+        <h3>Ideas to elevate your one pager</h3>
+        <ul>
+          <li>Auto-track week-over-week movement by pairing Smartsheet history data.</li>
+          <li>Suggest mitigations for blockers using similar past entries.</li>
+          <li>Generate targeted follow-up tasks in Jira, Asana, or Teams.</li>
+          <li>Provide stakeholder-specific variants (e.g., Sales vs Engineering).</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="panel report" id="report-panel">
+      <h2>One Page Summary</h2>
+      <div id="report-warning" class="status-message hidden"></div>
+      <article id="report-content" class="report-content">
+        <p class="hint">Load data and click "Generate Report" to see your one page summary.</p>
+      </article>
+    </section>
+  </main>
+
+  <footer class="app-footer">
+    <p>Built for GitHub Pages — no servers, just client-side generation. Keep your access tokens safe by revoking when finished.</p>
+  </footer>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-/3aRymNEzbGDbVS9/6uzxhpcJn/qdNqxabWWMwBLT/gRghOAqxCLv7saEh1PQuPgzpTUN324j6nUdfbWFzR4xA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdn.jsdelivr.net/npm/pptxgenjs@3.14.0/dist/pptxgen.bundle.js" integrity="sha384-vpbMkYG14TQXBsMf5E5zrGNmbE46cMfYbM8xOp6U17ZT/6J6oTQA1S6wN2MB+t5G" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/docx/8.3.3/docx.min.js" integrity="sha512-AEx14N/2zsr1MS11r9m8cLeNTEFzS9LtYkXDBZkzME2YkdE+5EYXPLkZX31lrT7xvFeoJEBhDigw1k3DybMT0A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script type="module" src="assets/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a static GitHub Pages app that pulls Smartsheet sheets and shared Google Docs meeting notes into a one page summary
- implement tone-aware narrative generation plus PDF, PPTX, and DOCX export options for the generated report
- document setup steps, integrations, and future enhancement ideas for the MVP

## Testing
- not run (static client-side site)


------
https://chatgpt.com/codex/tasks/task_e_68e432fbee3883279edc90df5fb3bb95